### PR TITLE
Remove build from start command for production

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "build": "tsc",
     "lint": "tslint -c tslint.json -p tsconfig.json --fix",
-    "start": "yarn build && node build/index.js",
+    "start": "node build/index.js",
     "start:development": "nodemon --ext ts --exec 'yarn lint && ts-node src/index.ts'",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "heroku-postbuild": "tsc && yarn typeorm migration:run",
+    "heroku-postbuild": "yarn build && yarn typeorm migration:run",
     "typeorm": "ts-node ./node_modules/.bin/typeorm"
   },
   "author": "Emiliano de Sejas",


### PR DESCRIPTION
### I did the following
- Remove `yarn build` from `start` command since heroku starts and stops the app when needed
  - The app is built in the `heroku-postbuild` command